### PR TITLE
Clean up explicit Python version tests

### DIFF
--- a/python/soma/html.py
+++ b/python/soma/html.py
@@ -51,55 +51,45 @@ _htmlEscape = None
 _lesserHtmlEscape = None
 
 
+# ylep 2020-03-24: now that UTF-8 is everywhere, shouldn't we just replace
+# HTML-unsafe characters (&<>"') and leave the rest untouched? (i.e. what the
+# standard library function html.escape does in Python 3.2 and later).
+
 def htmlEscape(msg):
-    """
-    Replace special characters in the message by their correponding html entity.
+    """Replace special characters by their correponding html entity.
+
+    All characters that have a corresponding named HTML entity are replaced.
 
     - returns: *unicode*
     """
     global _htmlEscape
     if _htmlEscape is None:
-        if sys.version_info[0] >= 3:
-            _htmlEscape = dict([(ord(j), u'&' + i + u';')
-                              for i, j
-                                  in six.iteritems(six.moves.html_entities.entitydefs)
-                                  if len(j) == 1])
-        else:
-            # htmlentitydefs is apparently encoded in iso-8859-1
-            # (*NOT* defaultencoding)
-            # (and this is not specified in the source code)
-            encoding = 'iso-8859-1'
-            _htmlEscape = dict(
-                [(ord(j.decode(encoding)), u'&' + i.decode(encoding) + u';')
-                 for i, j in six.iteritems(six.moves.html_entities.entitydefs)
-                 if len(j) == 1])
-    return six.text_type(msg).translate(_htmlEscape)
+        _htmlEscape = {
+            codepoint: u'&' + name + u';'
+            for codepoint, name
+            in six.iteritems(six.moves.html_entities.codepoint2name)
+        }
+    msg = six.ensure_text(msg)
+    return msg.translate(_htmlEscape)
 
 
 def lesserHtmlEscape(msg):
-    """
-    Replace special characters in the message by their correponding html entity.
+    """Replace special characters by their correponding html entity.
+
+    All characters that have a corresponding named HTML entity are replaced,
+    except accented characters commonly used in French text (éàèâêôîûàö) and
+    the double-quote character (").
 
     - returns: *unicode*
     """
     global _lesserHtmlEscape
     if _lesserHtmlEscape is None:
-        if sys.version_info[0] >= 3:
-            _lesserHtmlEscape = dict([(ord(j), u'&' + i + u';')
-                                    for i, j
-                                    in six.iteritems(six.moves.html_entities.entitydefs)
-                                    if len(j) == 1 and j not in
-                                        (u'"', u'é', u'à', u'è', u'â', u'ê',
-                                         u'ô', u'î', u'û', u'ù', u'ö', )])
-        else:
-            # htmlentitydefs is apparently encoded in iso-8859-1
-            # (*NOT* defaultencoding)
-            # (and this is not specified in the source code)
-            encoding = 'iso-8859-1'
-            _lesserHtmlEscape = dict(
-                [(ord(j.decode(encoding)), u'&' + i.decode(encoding) + u';')
-                 for i, j in six.iteritems(six.moves.html_entities.entitydefs)
-                 if len(j) == 1 and j.decode(encoding) not in
-                    (u'"', u'é', u'à', u'è', u'â', u'ê',
-                     u'ô', u'î', u'û', u'ù', u'ö', )])
-    return six.text_type(msg).translate(_lesserHtmlEscape)
+        _lesserHtmlEscape = {
+            codepoint: u'&' + name + u';'
+            for codepoint, name
+            in six.iteritems(six.moves.html_entities.codepoint2name)
+            if six.unichr(codepoint) not in ('"', 'é', 'à', 'è', 'â', 'ê',
+                                             'ô', 'î', 'û', 'ù', 'ö', )
+        }
+    msg = six.ensure_text(msg)
+    return msg.translate(_lesserHtmlEscape)

--- a/python/soma/html.py
+++ b/python/soma/html.py
@@ -88,8 +88,9 @@ def lesserHtmlEscape(msg):
             codepoint: u'&' + name + u';'
             for codepoint, name
             in six.iteritems(six.moves.html_entities.codepoint2name)
-            if six.unichr(codepoint) not in ('"', 'é', 'à', 'è', 'â', 'ê',
-                                             'ô', 'î', 'û', 'ù', 'ö', )
+            if six.unichr(codepoint) not in (u'"', u'é', u'à', u'è', u'â',
+                                             u'ê', u'ô', u'î', u'û', u'ù',
+                                             u'ö', )
         }
     msg = six.ensure_text(msg)
     return msg.translate(_lesserHtmlEscape)

--- a/python/soma/importer.py
+++ b/python/soma/importer.py
@@ -376,6 +376,6 @@ def execfile(filename, globals=None, locals=None):
     six.exec_() needs an open file, hence this wrapper for convenience.
     Files are open with UTF-8 encoding on python3.
     '''
-    fopts = {'encoding': 'utf-8'} if sys.version_info[0] >= 3 else {}
+    fopts = {} if six.PY2 else {'encoding': 'utf-8'}
     with open(filename, **fopts) as f:
         six.exec_(f, globals, locals)

--- a/python/soma/info.py
+++ b/python/soma/info.py
@@ -66,7 +66,7 @@ ISRELEASE = version_extra == ''
 VERSION = __version__
 PROVIDES = ["soma-base"]
 REQUIRES = [
-    "six",
+    "six ~= 1.12",
     "numpy",
 ]
 EXTRAS_REQUIRE = {

--- a/python/soma/minf/api.py
+++ b/python/soma/minf/api.py
@@ -195,7 +195,7 @@ def iterateMinf(source, targets=None, stop_on_error=True, exceptions=[]):
 
     initial_source = source
 
-    if sys.version_info[0] >= 3 and not hasattr(initial_source, 'readline'):
+    if not hasattr(initial_source, 'readline') and not six.PY2:
         # in python3 the encoding of a file should be specified when opening
         # it: it cannot be changed afterwards. So in python3 we cannot read
         # the encoding within the file (for instance in a XML file).
@@ -208,10 +208,10 @@ def iterateMinf(source, targets=None, stop_on_error=True, exceptions=[]):
     for encoding in try_encodings:
         opened_source_file = None
         if not hasattr(initial_source, 'readline'):
-            if sys.version_info[0] >= 3:
-                opened_source_file = open(initial_source, encoding=encoding)
-            else:
+            if six.PY2:
                 opened_source_file = open(initial_source)
+            else:
+                opened_source_file = open(initial_source, encoding=encoding)
             source = BufferAndFile(opened_source_file)
         elif not isinstance(source, BufferAndFile):
             source.seek(0)

--- a/python/soma/minf/tree.py
+++ b/python/soma/minf/tree.py
@@ -328,7 +328,7 @@ class MinfReducer(object):
 
         @returns: string or None
         '''
-        if isinstance(value, type) or (sys.version_info[0] <= 2 and type(value) is types.ClassType):
+        if isinstance(value, six.class_types):
             # value is a class
             cls = value
         else:

--- a/python/soma/minf/xhtml.py
+++ b/python/soma/minf/xhtml.py
@@ -140,8 +140,7 @@ class XHTML(object):
         io = StringIO()
         # when unicode string is written in a stream, default encoding is used
         # to encode it :
-        if sys.version_info[0] < 3:
-            html = html.encode('utf-8')
+        html = six.ensure_str(html, 'utf-8')
         io.write(
             '<?xml version="1.0" encoding="utf-8" ?>\n<' + minfTag + ' ' +
             expanderAttribute + '="minf_2.0">\n<' + xhtmlTag + '>' +

--- a/python/soma/minf/xml_writer.py
+++ b/python/soma/minf/xml_writer.py
@@ -213,8 +213,7 @@ class MinfXMLWriter(MinfWriter):
         else:
             indent = self.indentString * (self.level + level)
             nl = '\n'
-        if sys.version_info[0] >= 3 and isinstance(line, bytes):
-            line = line.decode('utf8')
+        line = six.ensure_text(line, 'utf8')
         try:
             self.__file.write(indent + line + nl)
         except TypeError:

--- a/python/soma/qt_gui/controls/List.py
+++ b/python/soma/qt_gui/controls/List.py
@@ -31,10 +31,7 @@ import json
 import csv
 import sys
 
-if sys.version_info[0] >= 3:
-    from io import StringIO
-else:
-    from cStringIO import StringIO
+from six.moves import cStringIO as StringIO
 
 # Qt import
 try:

--- a/python/soma/qt_gui/io.py
+++ b/python/soma/qt_gui/io.py
@@ -39,15 +39,12 @@ from __future__ import print_function
 from __future__ import absolute_import
 import threading
 import socket
-try:
-    # python 3
-    import queue
-except ImportError:
-    # python 2
-    import six.moves.queue as queue
 import errno
 import time
 import sys
+
+import six
+import six.moves.queue as queue
 
 from soma.qt_gui.qt_backend.QtCore import QObject, QSocketNotifier
 
@@ -314,10 +311,7 @@ class Socket(QObject):
                 else:
                     raise IOError(
                         errno.EPIPE, 'socket communication interrupted')
-        if sys.version_info[0] >= 3:
-            return msg.decode()
-        else:
-            return msg
+        return six.ensure_str(msg)
 
     def readMessage(self, timeout=30):
         """

--- a/python/soma/test_utils/test_notebook.py
+++ b/python/soma/test_utils/test_notebook.py
@@ -74,11 +74,7 @@ def notebook_run(path, timeout=60):
             # sys.exit()
             ret_code = soma.subprocess.call(args)
 
-            if sys.version_info[0] >= 3:
-                nb = nbformat.read(open(fout[1], encoding='utf-8'),
-                                   nbformat.current_nbformat)
-            else:
-                nb = nbformat.read(open(fout[1]), nbformat.current_nbformat)
+            nb = nbformat.read(fout[1], nbformat.current_nbformat)
         except Exception as e:
             print('EXCEPTION:', e)
             return None, [e]

--- a/python/soma/tests/test_misc.py
+++ b/python/soma/tests/test_misc.py
@@ -67,9 +67,6 @@ from soma import utils
 from soma import uuid
 
 
-if sys.version_info[0] < 3:
-    bytes = str
-
 class TestSomaMisc(unittest.TestCase):
 
     def test_singleton(self):

--- a/python/soma/tests/test_undefined.py
+++ b/python/soma/tests/test_undefined.py
@@ -6,8 +6,8 @@ from __future__ import absolute_import
 import unittest
 import os
 import sys
-if sys.version_info[0] >= 3:
-    from importlib import reload
+
+from six.moves import reload_module
 
 
 class TestUndefined(unittest.TestCase):
@@ -37,13 +37,13 @@ class TestUndefined(unittest.TestCase):
     def tearDown(self):
         self.restore_traits()
         from soma import undefined
-        reload(undefined)
+        reload_module(undefined)
 
     def test_undefined_builtin(self):
         sys.modules['traits'] = None
         sys.modules['traits.api'] = None
         from soma import undefined
-        reload(undefined)
+        reload_module(undefined)
         self.assertTrue(hasattr(undefined, 'Undefined'))
         undef = undefined.Undefined
         self.assertTrue(isinstance(undef, undefined.UndefinedClass))
@@ -56,7 +56,7 @@ class TestUndefined(unittest.TestCase):
         from soma import undefined
         from traits import trait_base
         import traits.api as traits
-        reload(undefined)
+        reload_module(undefined)
         self.assertTrue(hasattr(undefined, 'Undefined'))
         undef = undefined.Undefined
         self.assertTrue(isinstance(undef, trait_base._Undefined))

--- a/python/soma/tests/test_uuid.py
+++ b/python/soma/tests/test_uuid.py
@@ -17,29 +17,27 @@ class TestUUID(unittest.TestCase):
     def test_uuid(self):
         u1 = uuid.Uuid()
         u2 = uuid.Uuid()
-        self.assertTrue(u1 != u2)
-        self.assertTrue(str(u1) != str(u2))
+        self.assertNotEqual(u1, u2)
+        self.assertNotEqual(str(u1), str(u2))
         self.assertEqual(len(str(u1)), 36)
         self.assertEqual(len(repr(u1)), 38)
         self.assertEqual(u1, uuid.Uuid(str(u1)))
-        self.assertTrue(u1 is uuid.Uuid(u1))
+        self.assertIs(u1, uuid.Uuid(u1))
         self.assertEqual(u1, str(u1))
         self.assertTrue(u1 != str(u2))
         self.assertTrue(u1 != 'bloblo')
         self.assertTrue(u1 != 12)
         self.assertTrue(not(u1 == 'bloblo'))
         self.assertTrue(not(u1 == 12))
-        self.assertRaises(ValueError, uuid.Uuid,
-                          'blablah0-bouh-bidi-bada-popogugurbav')
+        with self.assertRaises(ValueError):
+            uuid.Uuid('blablah0-bouh-bidi-bada-popogugurbav')
         p = pickle.dumps(u1)
         self.assertEqual(u1, pickle.loads(p))
         p = pickle.dumps(u1, 2)  # test Pickle protocol version 2
         self.assertEqual(u1, pickle.loads(p))
-        d = {u1: 'u1'}
-        self.assertTrue(u1 in d)
-        d[u1] = 'u1-bis'
-        self.assertEqual(len(d), 1)
-        self.assertEqual(d[u1], 'u1-bis')
+        u3 = uuid.Uuid(b'1cab3907-9056-4694-a1d5-266ed5b6ebe3')
+        u4 = uuid.Uuid(u'1cab3907-9056-4694-a1d5-266ed5b6ebe3')
+        self.assertEqual(u3, u4)
 
 
 def test():

--- a/python/soma/uuid.py
+++ b/python/soma/uuid.py
@@ -85,6 +85,7 @@ class Uuid(object):
                                       random.randrange(2 ** 64 - 1))
         else:
             try:
+                uuid = six.ensure_binary(uuid, encoding='ascii')
                 self.__uuid = binascii.unhexlify(uuid[0:8] + uuid[9:13] +
                                                  uuid[14:18] + uuid[19:23] +
                                                  uuid[24:36])
@@ -94,23 +95,21 @@ class Uuid(object):
     def __getnewargs__(self):
         return (str(self), )
 
-    if sys.version_info[0] >= 3:
-        def __str__(self):
-            if not isinstance(self.__uuid, bytes):
-                # this should not happen, but has been seen in some places
-                self.__uuid = bytes(self.__uuid, encoding='utf-8')
-            return (binascii.hexlify( self.__uuid[0:4] ) + b'-' + \
-                binascii.hexlify( self.__uuid[4:6] ) + b'-' + \
-                binascii.hexlify( self.__uuid[6:8] ) + b'-' + \
-                binascii.hexlify( self.__uuid[8:10] ) + b'-' + \
-                binascii.hexlify(self.__uuid[10:16])).decode()
-    else:
-        def __str__(self):
-            return binascii.hexlify( self.__uuid[0:4] ) + '-' + \
-                binascii.hexlify( self.__uuid[4:6] ) + '-' + \
-                binascii.hexlify( self.__uuid[6:8] ) + '-' + \
-                binascii.hexlify( self.__uuid[8:10] ) + '-' + \
-                binascii.hexlify(self.__uuid[10:16])
+    def __str__(self):
+        if not isinstance(self.__uuid, bytes):
+            # this should not happen, but has been seen in some places
+            import warnings
+            warnings.warn('soma.uuid.Uuid: self.__uuid is not of type bytes, '
+                          'but {0}. This is not supposed to happen.'
+                          .format(type(self.__uuid)))
+            self.__uuid = bytes(self.__uuid, encoding='utf-8')
+        return six.ensure_str(
+            binascii.hexlify(self.__uuid[0:4]) + b'-' +
+            binascii.hexlify(self.__uuid[4:6]) + b'-' +
+            binascii.hexlify(self.__uuid[6:8]) + b'-' +
+            binascii.hexlify(self.__uuid[8:10]) + b'-' +
+            binascii.hexlify(self.__uuid[10:16])
+        )
 
     def __repr__(self):
         return repr(str(self))


### PR DESCRIPTION
I tried to remove all explicit tests of the Python version (`six.version_info` and friends), and replace them with cleaner `six`-based solutions.

One possible downside of my changes is that `soma-base` has to depend on `six` version 1.12 or later. Feel free to reject the review if that is not acceptable, in that case I will try to get rid of that dependency.