### PR TITLE
Make class fields read-only

### DIFF
--- a/python/soma/controller/controller.py
+++ b/python/soma/controller/controller.py
@@ -397,7 +397,6 @@ class Controller(metaclass=ControllerMeta, ignore_metaclass=True):
                 self.__class__._order += 1
                 kwargs["order"] = self.__class__._order
             new_field = field(type_=type_, default=default, metadata=metadata, **kwargs)
-            print("!add_field.new_field!", new_field.name, type_, new_field)
             namespace = {
                 "__annotations__": {
                     name: new_field,

--- a/python/soma/controller/field.py
+++ b/python/soma/controller/field.py
@@ -320,7 +320,7 @@ class Field:
         return value
 
     def __setattr__(self, name, value):
-        self._dataclass_field.metadata["_metadata"][name] = value
+        raise AttributeError(f"can't set attribute {name} of a class field")
 
     def __delattr__(self, name):
         del self._dataclass_field.metadata["_metadata"][name]
@@ -408,34 +408,34 @@ class Field:
             optional = self.has_default()
         return optional
 
-    @optional.setter
-    def optional(self, optional):
-        self._dataclass_field.metadata["_metadata"]["optional"] = optional
-
-    @optional.deleter
-    def optional(self):
-        del self._dataclass_field.metadata["_metadata"]["optional"]
-
     @property
     def doc(self):
         """Field documentation string"""
         return self.__getattr__("doc")
 
-    @doc.setter
+    def parse_type_str(self):
+        return parse_type_str(self.type_str())
+
+
+class WritableField(Field):
+    def __setattr__(self, name, value):
+        self._dataclass_field.metadata["_metadata"][name] = value
+
+    @Field.optional.setter
+    def optional(self, optional):
+        self._dataclass_field.metadata["_metadata"]["optional"] = optional
+
+    @Field.optional.deleter
+    def optional(self):
+        del self._dataclass_field.metadata["_metadata"]["optional"]
+
+    @Field.doc.setter
     def doc(self, doc):
         self.__setattr__("doc", doc)
 
-    @doc.deleter
+    @Field.doc.deleter
     def doc(self):
         self.__delattr__("doc")
-
-    # The following methods are available as functions but global
-    # functions are not available in Jinja2 context used to create Web-based
-    # GUI. Therefore, an access to the function from a field instance had
-    # been added whenever necessary.
-
-    def parse_type_str(self):
-        return parse_type_str(self.type_str())
 
 
 def field(
@@ -507,7 +507,9 @@ def field(
                     break
             if isinstance(current_type, type) and issubclass(current_type, Path):
                 path_type = current_type.__name__.lower()
-    if field_class is Field:
+    if field_class in (Field, WritableField):
+        if not metadata.get("class_field"):
+            field_class = WritableField
         metadata["path_type"] = path_type
         if path_type:
             metadata.setdefault("read", True)
@@ -570,7 +572,7 @@ class FieldProxy:
 class ListProxy(Field):
     """
     This class is used internally to represent a field that has a list value
-    but whose type and metadata are linked to anotehr field of another
+    but whose type and metadata are linked to another field of another
     controller.
     """
 

--- a/python/soma/controller/field.py
+++ b/python/soma/controller/field.py
@@ -320,7 +320,9 @@ class Field:
         return value
 
     def __setattr__(self, name, value):
-        raise AttributeError(f"can't set attribute {name} of a class field")
+        raise AttributeError(
+            f"can't set attribute {name} of a class field ({self.name})"
+        )
 
     def __delattr__(self, name):
         del self._dataclass_field.metadata["_metadata"][name]
@@ -569,7 +571,7 @@ class FieldProxy:
         delattr(self.target_field, name)
 
 
-class ListProxy(Field):
+class ListProxy(WritableField):
     """
     This class is used internally to represent a field that has a list value
     but whose type and metadata are linked to another field of another

--- a/python/soma/qt_gui/test/test.py
+++ b/python/soma/qt_gui/test/test.py
@@ -100,8 +100,6 @@ if __name__ == "__main__":
     widget2 = ControllerWidget(controller)
     widget1.show()
     widget2.show()
-    print("!widget1", widget1)
-    print("!widget2", widget2)
 
     # Start the qt loop
     app.exec_()


### PR DESCRIPTION
Fields defined on class are now supposed to be read-only. As a consequence, it is not possible to use standard API to change their metadata. In order to be able to do this, a class field must first be copied in the instance. This can be done using the controller method writable_field() that behave like field() but in case of class a field, it first copy the field in the instance.