### PR TITLE
Use the ruff formatter, instead of black

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
-# See https://pre-commit.com for more information
-# See https://pre-commit.com/hooks.html for more hooks
+exclude: '^doc/'
+
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.5.0
@@ -19,13 +19,9 @@ repos:
     -   id: end-of-file-fixer
     -   id: fix-byte-order-marker
     -   id: trailing-whitespace
--   repo: https://github.com/psf/black
-    rev: 23.11.0
+
+-   repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.1.7
     hooks:
-      - id: black
-        exclude: '^doc/'
-#-   repo: https://github.com/astral-sh/ruff-pre-commit
-#    rev: v0.1.5
-#    hooks:
-#    -   id: ruff
-#        exclude: '^doc/'
+    #-   id: ruff
+    -   id: ruff-format

--- a/python/soma/controller/controller.py
+++ b/python/soma/controller/controller.py
@@ -102,23 +102,43 @@ class AttributeValueEvent(Event):
         signature = inspect.signature(pcallback)
         if len(signature.parameters) == 0:
             return (
-                lambda new_value, old_value, attribute_name, controller, index: callback()
+                lambda new_value,
+                old_value,
+                attribute_name,
+                controller,
+                index: callback()
             )
         elif len(signature.parameters) == 1:
-            return lambda new_value, old_value, attribute_name, controller, index: callback(
-                new_value
+            return (
+                lambda new_value,
+                old_value,
+                attribute_name,
+                controller,
+                index: callback(new_value)
             )
         elif len(signature.parameters) == 2:
-            return lambda new_value, old_value, attribute_name, controller, index: callback(
-                new_value, old_value
+            return (
+                lambda new_value,
+                old_value,
+                attribute_name,
+                controller,
+                index: callback(new_value, old_value)
             )
         elif len(signature.parameters) == 3:
-            return lambda new_value, old_value, attribute_name, controller, index: callback(
-                new_value, old_value, attribute_name
+            return (
+                lambda new_value,
+                old_value,
+                attribute_name,
+                controller,
+                index: callback(new_value, old_value, attribute_name)
             )
         elif len(signature.parameters) == 4:
-            return lambda new_value, old_value, attribute_name, controller, index: callback(
-                new_value, old_value, attribute_name, controller
+            return (
+                lambda new_value,
+                old_value,
+                attribute_name,
+                controller,
+                index: callback(new_value, old_value, attribute_name, controller)
             )
         elif len(signature.parameters) == 5:
             return callback

--- a/python/soma/importer.py
+++ b/python/soma/importer.py
@@ -33,7 +33,7 @@ class ExtendedImporter(Singleton):
         namespacesList=[],
         handlersList=None,
         *args,
-        **kwargs
+        **kwargs,
     ):
         """
         This method is used to import a module applying rules (rename rule, delete rule, ...) .

--- a/python/soma/notification.py
+++ b/python/soma/notification.py
@@ -1063,11 +1063,7 @@ class EditableTree(ObservableAttributes, ObservableSortedDictionary):
             if (
                 not item.isLeaf()
             ):  # if the item is a leaf and is already in the tree, nothing to do
-                for (
-                    v
-                ) in (
-                    item.values()
-                ):  # item is also a dictionary and contains several elements, add each value in the tree item
+                for v in item.values():  # item is also a dictionary and contains several elements, add each value in the tree item
                     self[key].add(v)
             # also set current name for the current object
             self[key].name = item.name
@@ -1208,7 +1204,7 @@ class EditableTree(ObservableAttributes, ObservableSortedDictionary):
             delEnabled=True,
             visible=True,
             enabled=True,
-            *args
+            *args,
         ):
             super().__init__(*args)
             self.icon = icon
@@ -1337,7 +1333,7 @@ class EditableTree(ObservableAttributes, ObservableSortedDictionary):
                 delEnabled,
                 visible,
                 enabled,
-                *dictContent
+                *dictContent,
             )
             if name is None:
                 self.name = self.defaultName
@@ -1391,14 +1387,10 @@ class EditableTree(ObservableAttributes, ObservableSortedDictionary):
             """
             key = item.id
             if key in self:
-                if not self[
-                    key
-                ].isLeaf():  # if the item is a leaf and is already in the tree, nothing to do
-                    for (
-                        v
-                    ) in (
-                        item.values()
-                    ):  # item is also a dictionary and contains several elements, add each value in the tree item
+                if (
+                    not self[key].isLeaf()
+                ):  # if the item is a leaf and is already in the tree, nothing to do
+                    for v in item.values():  # item is also a dictionary and contains several elements, add each value in the tree item
                         self[key].add(v)
 
                 # also set current name for the current object

--- a/python/soma/qt_gui/predef_lineedit.py
+++ b/python/soma/qt_gui/predef_lineedit.py
@@ -29,7 +29,7 @@ class QPredefLineEdit(Qt.QLineEdit):
         allow_none=False,
         allow_undefined=False,
         *args,
-        **kwargs
+        **kwargs,
     ):
         if parent is not None:
             args = (parent,) + args

--- a/python/soma/topological_sort.py
+++ b/python/soma/topological_sort.py
@@ -175,13 +175,15 @@ class Graph:
         """
         if from_node not in self._nodes:
             raise Exception(
-                "Node {0} is not defined in the Graph."
-                "Use add_node() method".format(from_node)
+                "Node {0} is not defined in the Graph." "Use add_node() method".format(
+                    from_node
+                )
             )
         if to_node not in self._nodes:
             raise Exception(
-                "Node {0} is not defined in the Graph."
-                "Use add_node() method".format(to_node)
+                "Node {0} is not defined in the Graph." "Use add_node() method".format(
+                    to_node
+                )
             )
         if (from_node, to_node) not in self._links:
             self._nodes[to_node].add_link_from(self._nodes[from_node])

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,25 @@
+exclude = [
+  "doc",
+]
+
+[lint]
+extend-ignore = [
+  # https://docs.astral.sh/ruff/rules/redundant-open-modes/
+  # we prefer explicit to implicit open modes
+  "UP015",
+  # https://docs.astral.sh/ruff/formatter/#conflicting-lint-rules
+  "W191",
+  "E111",
+  "E114",
+  "E117",
+  "D206",
+  "D300",
+  "Q000",
+  "Q001",
+  "Q002",
+  "Q003",
+  "COM812",
+  "COM819",
+  "ISC001",
+  "ISC002",
+]

--- a/ruff.toml
+++ b/ruff.toml
@@ -3,6 +3,10 @@ exclude = [
 ]
 
 [lint]
+extend-select = [
+  "I",   # https://docs.astral.sh/ruff/rules/#isort-i
+  "UP",  # https://docs.astral.sh/ruff/rules/#pyupgrade-up
+]
 extend-ignore = [
   # https://docs.astral.sh/ruff/rules/redundant-open-modes/
   # we prefer explicit to implicit open modes


### PR DESCRIPTION
The ruff formatter seems to gain traction. Replacing [black](https://github.com/psf/black) with [ruff](https://github.com/astral-sh/ruff) means one less tool to depend on.

I have based this commit on:
- ruff-pre-commit [README.md](https://github.com/astral-sh/ruff-pre-commit/blob/main/README.md) | Using Ruff with pre-commit
- The Ruff Formatter | [Conflicting lint rules](https://docs.astral.sh/ruff/formatter/#conflicting-lint-rules)

Also add new ruff linter rules.