### PR TITLE
Fix typo

### DIFF
--- a/python/soma/controller/field.py
+++ b/python/soma/controller/field.py
@@ -3,7 +3,7 @@ import re
 import sys
 import typing
 
-# Import allsupported types from typing
+# Import all supported types from typing
 from typing import (
     Any,
     Literal,


### PR DESCRIPTION
@denisri Should we get rid of this altogether?
```python
# More supported types, in Python < 3.9 style
Tuple = tuple
Dict = dict
Set = set
```
I'm afraid it could break compatibility with existing code.