### PR TITLE
Fix repo-review issue

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,3 +5,7 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
GH212: Require GHA update grouping

Projects should group their updates to avoid extra PRs and stay in sync. This is now supported by dependabot since June 2023.