### PR TITLE
Added soma.config.soma_root_dir

### DIFF
--- a/python/soma/__init__.py
+++ b/python/soma/__init__.py
@@ -1,1 +1,18 @@
 from .info import __version__  # noqa: F401
+import os
+
+
+def root_path():
+    """Return the path of the base directory where software is installed. In a
+    developpement environment this corresponds to the build directory. In
+    user environments this corresponds to the install directory (which is
+    $CONDA_PREFIX in the case of a Conda, Mamba or Pixi environment)
+    """
+    root_path = os.environ.get("SOMA_ROOT")
+    if not root_path:
+        root_path = os.environ.get("CASA_BUILD")
+        if not root_path:
+            root_path = os.environ.get("CONDA_PREFIX")
+            if not root_path:
+                raise EnvironmentError("cannot find soma root path")
+    return root_path

--- a/python/soma/__init__.py
+++ b/python/soma/__init__.py
@@ -1,18 +1,1 @@
 from .info import __version__  # noqa: F401
-import os
-
-
-def root_path():
-    """Return the path of the base directory where software is installed. In a
-    developpement environment this corresponds to the build directory. In
-    user environments this corresponds to the install directory (which is
-    $CONDA_PREFIX in the case of a Conda, Mamba or Pixi environment)
-    """
-    root_path = os.environ.get("SOMA_ROOT")
-    if not root_path:
-        root_path = os.environ.get("CASA_BUILD")
-        if not root_path:
-            root_path = os.environ.get("CONDA_PREFIX")
-            if not root_path:
-                raise EnvironmentError("cannot find soma root path")
-    return root_path

--- a/python/soma/config.py
+++ b/python/soma/config.py
@@ -11,6 +11,7 @@ BRAINVISA_SHARE
 """
 
 import os
+from pathlib import Path
 
 import soma.info
 
@@ -75,7 +76,12 @@ def find_soma_root_dir():
         if not soma_root_dir:
             soma_root_dir = os.environ.get("CONDA_PREFIX")
             if not soma_root_dir:
-                raise EnvironmentError("cannot find soma root directory")
+                soma_root_dir = Path(__file__).parent
+                for i in range(3):
+                    soma_root_dir = soma_root_dir.parent
+                    if soma_root_dir.name in ("lib", "src"):
+                        soma_root_dir = soma_root_dir.parent
+                        return str(soma_root_dir)
     return soma_root_dir
 
 

--- a/python/soma/config.py
+++ b/python/soma/config.py
@@ -63,4 +63,21 @@ def _init_default_brainvisa_share():
     return share
 
 
+def find_soma_root_dir():
+    """Return the path of the base directory where software is installed. In a
+    developpement environment this corresponds to the build directory. In
+    user environments this corresponds to the install directory (which is
+    $CONDA_PREFIX in the case of a Conda, Mamba or Pixi environment)
+    """
+    soma_root_dir = os.environ.get("SOMA_ROOT")
+    if not soma_root_dir:
+        soma_root_dir = os.environ.get("CASA_BUILD")
+        if not soma_root_dir:
+            soma_root_dir = os.environ.get("CONDA_PREFIX")
+            if not soma_root_dir:
+                raise EnvironmentError("cannot find soma root directory")
+    return soma_root_dir
+
+
 BRAINVISA_SHARE = _init_default_brainvisa_share()
+soma_root_dir = find_soma_root_dir()


### PR DESCRIPTION
The base directory where various files are installed via `make install` depends on the environment:

- In development environment this is the build directory
- In casa-distro container this is the install directory
- In user environment deployed via conda packages, this is the base directory of conda (i.e. `$CONDA_PREFIX)

I added a new `soma.config.soma_root_dir` variable that always contains the appropriate value in all environments.