### PR TITLE
Updated advanced customization of QT module import process

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,8 +2,9 @@ environment:
 
   matrix:
 
-    - PYTHON: "C:\\Python27"
-    - PYTHON: "C:\\Python35"
+    - PYTHON: "C:\\Python310"
+    - PYTHON: "C:\\Python311"
+    - PYTHON: "C:\\Python312"
 
 build: off
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,7 @@
+image: Visual Studio 2022
+
 environment:
-
   matrix:
-
     - PYTHON: "C:\\Python39"
     - PYTHON: "C:\\Python311"
 

--- a/python/soma/qt_gui/qt_backend.py
+++ b/python/soma/qt_gui/qt_backend.py
@@ -97,6 +97,8 @@ class QtImporter(object):
                         return None
                 except ImportError:
                     return None
+        if found is None:
+            return None
         found.loader = self
         return found
 


### PR DESCRIPTION
As discussed in private messages, the current advanced customization of the soma QT module import process is not working since python 3.12.

In the [qt_backend](https://github.com/populse/soma-base/blob/ae2b109266a701860f72187c67b6197e27ce2607/python/soma/qt_gui/qt_backend.py#L64) module, finders and loaders have been outdated for several versions of Python.

Since python 3.4, the `find_spec()` method of the finders metapath has replaced `find_module()`, which is now obsolete.

Between python 3.4 and python 3.11, the import machinery still accepts `find_module()`, but since python 3.12 `find_module()` has been removed. 

As for the loader, since python 3.4, the `load_module()` method has been replaced by `exec_module()`. In addition, the `create_module()` method is no longer optional when `exec_module()` is defined. Since Python 3.4, the recommended API for loading a module is `exec_module()` (and `create_module()`).

It seems to me that the substance of what has been done is still good, and that this PR is above all an update of the machinery in line with current recommendations (since Python 3.4).

I've just tested with python 3.9 and the changes haven't introduced any regression.

I won't have access to python 3.10 and especially 3.12 until next Friday. I'll be testing with these two versions of python and I think that if there are no regressions we'll be able to merge this branch.

I'll be back here on Friday to give the result with python 3.12 (and 3.10).

I also noticed that the crash in UT for the master branch are also in the qt_backend (I haven't looked into why, but I can have a look if it's useful...).